### PR TITLE
Fix whatsdone-app build: downgrade uuid to 11.0.2 + gate tsc in PR checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,69 @@
+# Dependabot configuration.
+#
+# Until this file existed, Dependabot ran on auto-detected manifests. The
+# entries below mirror that status quo (every directory where dependabot has
+# historically opened bumps) plus an explicit ignore rule documented below.
+#
+# When adding a new module with a package.json / pyproject.toml, please add a
+# matching entry here.
+
+version: 2
+updates:
+  # ---- npm (Node.js) ----
+  - package-ecosystem: npm
+    directory: /modules/whatsdone-app
+    schedule:
+      interval: daily
+    ignore:
+      # uuid >= 11.0.3 ships type declarations that use TypeScript 5 syntax
+      # (`export type * from ...`), which fails to compile under the
+      # `typescript@^4.1.3` we currently use in this module. uuid 11.0.2 is
+      # the last TS-4-compatible release. The CVE that triggered the original
+      # bump (GHSA-w5hq-g745-h8pq, missing buffer bounds check in v3/v5/v6
+      # when buf is provided, patched in 11.1.1) does not affect this module:
+      # the only call site is `Uuid.v4()` in ServiceFactory.ts with no buf
+      # argument. Drop this rule once TypeScript is upgraded to 5.x in this
+      # module (see TODO.md "TypeScript 5 upgrade").
+      - dependency-name: uuid
+        versions: [">=11.0.3"]
+
+  - package-ecosystem: npm
+    directory: /modules/whatsdone-app/ops
+    schedule:
+      interval: daily
+
+  - package-ecosystem: npm
+    directory: /modules/whatsdone-assets
+    schedule:
+      interval: daily
+
+  - package-ecosystem: npm
+    directory: /modules/whatsdone-assets/app
+    schedule:
+      interval: daily
+
+  - package-ecosystem: npm
+    directory: /test/e2e
+    schedule:
+      interval: weekly
+
+  # ---- pip (Python) ----
+  - package-ecosystem: pip
+    directory: /ml
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /tools/done-analysis
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /tools/topic-classification
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /tools/topic-classification/ops
+    schedule:
+      interval: weekly

--- a/modules/whatsdone-app/package.json
+++ b/modules/whatsdone-app/package.json
@@ -16,7 +16,7 @@
     "predeploy": "yarn run build && yarn run coverage",
     "deploy": "cd ops && yarn && kumo deploy-module --verbose",
     "destroy": "cd ops && kumo destroy-module --verbose",
-    "test_module": "yarn && yarn run lint && yarn test"
+    "test_module": "yarn && yarn run compile && yarn run lint && yarn test"
   },
   "dependencies": {
     "aws-sdk": "~2.820.0",
@@ -28,7 +28,7 @@
     "lodash.pick": "~4.4.0",
     "route-parser": "0.0.5",
     "tslib": "^2.6.2",
-    "uuid": "~14.0.0"
+    "uuid": "11.0.2"
   },
   "devDependencies": {
     "@types/lodash.get": "^4.4.6",
@@ -39,7 +39,6 @@
     "@types/mocha": "^8.2.0",
     "@types/node": "^12.19.11",
     "@types/route-parser": "^0.1.3",
-    "@types/uuid": "^8.3.0",
     "mocha": "^8.2.1",
     "nyc": "^15.1.0",
     "testdouble": "^3.16.1",

--- a/modules/whatsdone-app/yarn.lock
+++ b/modules/whatsdone-app/yarn.lock
@@ -424,11 +424,6 @@
     "@types/mime" "*"
     "@types/node" "*"
 
-"@types/uuid@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
-  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
-
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
@@ -1870,6 +1865,11 @@ url@0.10.3:
     punycode "1.3.2"
     querystring "0.2.0"
 
+uuid@11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.2.tgz#a8d68ba7347d051e7ea716cc8dcbbab634d66875"
+  integrity sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==
+
 uuid@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
@@ -1879,11 +1879,6 @@ uuid@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
-
-uuid@~14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
-  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
## Why

The Dependabot bump of `uuid` `8.3.2 → 14.0.0` in `modules/whatsdone-app`
(commit f5afaf8) broke `ci-deploy` on `main` with:

```
node_modules/uuid/dist/index.d.ts(5,1): error TS1383:
Only named exports may use 'export type'.
```

Failing run: https://github.com/ryu1kn/whatsdone/actions/runs/26132545346/job/76860568948

`uuid` ships TS 5 syntax (`export type * from …`) in its `.d.ts` from
`11.0.3` onwards, but this module is still on `typescript@^4.1.3`.

The CVE that triggered the bump (GHSA-w5hq-g745-h8pq, missing buffer
bounds check in `v3`/`v5`/`v6` when `buf` is provided, patched in
`11.1.1`) does **not** affect this codebase: the only call site is
`Uuid.v4()` in `ServiceFactory.ts:121`, with no `buf` argument.

## What is changed

**`774c2cf` — fix build & close the CI gap**

- Pin `uuid` exactly to `11.0.2` (last TS-4-compatible release;
  `~11.0.2` resolves to `11.0.5` and re-introduces the TS 5 syntax).
- Remove `@types/uuid` — uuid 11 ships its own types.
- Add `yarn run compile` to `test_module`. The PR gate previously ran
  only `lint` (tslint) + `test` (mocha via ts-node), neither of which
  type-checks `node_modules/*.d.ts` the way `tsc -p ./` does. Verified
  locally that, with this change, temporarily reverting `uuid` to 14
  makes `test_module` fail at the `tsc` step with the same `TS1383`
  error — so a future Dependabot PR of this shape will now be blocked
  at `pr-check` instead of breaking `main`.

**`6db0072` — make Dependabot scope explicit & ignore the bad uuid range**

- Add `.github/dependabot.yml`. Until now Dependabot ran with no config
  file, relying on auto-detection. Adding an explicit config so the
  ignore rule below can be carried without silently changing what is
  monitored. Entries mirror the directories where Dependabot has
  historically opened bumps (5 npm + 4 pip manifests).
- Ignore `uuid >= 11.0.3` in `modules/whatsdone-app`. Using a version
  range (not `update-types: semver-major`) because the TS 5 syntax was
  introduced in a patch release — a major-only ignore would let
  `11.0.5`, `11.1.x`, etc. through and break us again. Drop this rule
  once TypeScript 5 lands.
- Cadence: `daily` for everything under `/modules/`, `weekly` elsewhere.

## Follow-ups (separate work)

- Dismiss the four open Dependabot uuid alerts (#398, #397, #400, #395)
  as "tolerable risk / vulnerable code not in execution path".
- Upgrade `typescript` to 5.x across `whatsdone-app` and
  `whatsdone-assets`, then drop the `uuid >= 11.0.3` ignore.
- Plug the analogous gap in `whatsdone-assets` (webpack uses
  `babel-loader` which strips types but does not check; `tsconfig.json`
  there sets `skipLibCheck: true`). Deferred per discussion.
